### PR TITLE
Fix authors

### DIFF
--- a/automatic/jabref/jabref.nuspec
+++ b/automatic/jabref/jabref.nuspec
@@ -6,7 +6,7 @@
     <id>{{PackageName}}</id>
     <title>JabRef</title>
     <version>{{PackageVersion}}</version>
-    <authors>Oren Patashnik and Leslie Lamport</authors>
+    <authors>The JabRef team</authors>
     <owners>Vaquero</owners>
     <summary>JabRef is an open source bibliography reference manager. The native file format used by JabRef is BibTeX, the standard LaTeX bibliography format. JabRef runs on the Java VM (version 1.8 or newer).</summary>
     <description>


### PR DESCRIPTION
The authors/developers/maintainers of JabRef are listed at https://github.com/JabRef/jabref/blob/master/DEVELOPERS

All authors are listed at https://github.com/JabRef/jabref/blob/master/AUTHORS

Oren Patashnik and Leslie Lamport unfortunately were never contributing to JabRef.
